### PR TITLE
URL Cleanup

### DIFF
--- a/spring-session-bom.txt
+++ b/spring-session-bom.txt
@@ -1,1 +1,1 @@
-Maven Bill of Materials (BOM). See http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies
+Maven Bill of Materials (BOM). See https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Importing_Dependencies


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html with 1 occurrences migrated to:  
  https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html ([https](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html) result 200).