### PR TITLE
Work Around spring-gradle-plugins/dependency-management-plugin#277

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import io.spring.nohttp.gradle.NoHttpCheckstylePlugin
+
 buildscript {
 	dependencies {
 		classpath 'io.spring.gradle:spring-build-conventions:0.0.26.RELEASE'
@@ -9,7 +11,7 @@ buildscript {
 	}
 }
 
-apply plugin: 'io.spring.convention.root'
+apply plugin: NoHttpCheckstylePlugin
 apply plugin: 'io.spring.convention.springdependencymangement'
 apply plugin: 'io.spring.convention.maven'
 apply plugin: 'io.spring.convention.artifactory'
@@ -19,6 +21,10 @@ description = 'Spring Session Maven Bill of Materials (BOM)'
 
 artifacts {
 	archives file('spring-session-bom.txt')
+}
+
+repositories {
+	mavenCentral()
 }
 
 dependencyManagement {
@@ -76,11 +82,19 @@ task deployArtifacts {
 	description = 'Deploys the artifacts to either Artifactory or Maven Central'
 }
 
+def finalizeDeployArtifacts = project.task("finalizeDeployArtifacts")
+
 if (version.matches(/^.*-RELEASE$/) || version.matches(/^.*-SR\d+$/)) {
+	if (project.hasProperty("ossrhUsername")) {
+		project.ext.nexusUsername = project.ossrhUsername
+		project.ext.nexusPassword = project.ossrhPassword
+		project.getPluginManager().apply("io.codearte.nexus-staging")
+		finalizeDeployArtifacts.dependsOn project.tasks.closeAndReleaseRepository
+		project.nexusStaging.packageGroup = 'org.springframework'
+	}
+
 	deployArtifacts.dependsOn uploadArchives
 }
 else {
 	deployArtifacts.dependsOn artifactoryPublish
 }
-
-sonarqube.skipProject = true


### PR DESCRIPTION
Works around spring-gradle-plugins/dependency-management-plugin#277 by avoiding adding the `NoHttpCliPlugin`