### PR TITLE
Connect build to ge.spring.io to benefit from deep build insights and faster builds

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -8,9 +8,6 @@ on:
 
 env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  GRADLE_ENTERPRISE_CACHE_USER: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
-  GRADLE_ENTERPRISE_SECRET_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
   COMMIT_OWNER: ${{ github.event.pusher.name }}
   COMMIT_SHA: ${{ github.sha }}
   STRUCTURE101_LICENSEID: ${{ secrets.STRUCTURE101_LICENSEID }}
@@ -46,9 +43,6 @@ jobs:
           echo 'systemProp.user.name=spring-builds+github' >> ~/.gradle/gradle.properties
       - name: Deploy artifacts
         run: |
-          export GRADLE_ENTERPRISE_CACHE_USERNAME="$GRADLE_ENTERPRISE_CACHE_USER"
-          export GRADLE_ENTERPRISE_CACHE_PASSWORD="$GRADLE_ENTERPRISE_CACHE_PASSWORD"
-          export GRADLE_ENTERPRISE_ACCESS_KEY="$GRADLE_ENTERPRISE_SECRET_ACCESS_KEY"
           ./gradlew publishArtifacts finalizeDeployArtifacts -PossrhUsername="$OSSRH_TOKEN_USERNAME" -PossrhPassword="$OSSRH_TOKEN_PASSWORD" -PartifactoryUsername="$ARTIFACTORY_USERNAME" -PartifactoryPassword="$ARTIFACTORY_PASSWORD" --stacktrace
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -57,6 +51,9 @@ jobs:
           OSSRH_TOKEN_PASSWORD: ${{ secrets.OSSRH_S01_TOKEN_PASSWORD }}
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_SECRET_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
+          GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USER }}
   notify_result:
     name: Check for failures
     needs: [deploy_artifacts]

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 :release-version: 2021.1.1
 :dependency-management-plugin-version: 1.0.11.RELEASE
-= Spring Session BOM
+= Spring Session BOM image:https://img.shields.io/badge/Revved%20up%20by-Gradle%20Enterprise-06A0CE?logo=Gradle&labelColor=02303A["Revved up by Gradle Enterprise", link="https://ge.spring.io/scans?&search.rootProjectNames=spring-session-bom"]
 
 This repository contains Spring Session Maven Bill of Materials (BOM).
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 version=2021.2.3-SNAPSHOT
 springSessionCoreVersion=2.7.2
 springSessionDataGeodeVersion=2.7.1
+org.gradle.caching=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,13 @@
+pluginManagement {
+	repositories {
+		gradlePluginPortal()
+		maven { url 'https://repo.spring.io/release' }
+	}
+}
+
+plugins {
+	id 'com.gradle.enterprise' version '3.14.1'
+	id 'io.spring.ge.conventions' version '0.0.14'
+}
+
 rootProject.name = 'spring-session-bom'


### PR DESCRIPTION
This pull request connects the build to the Gradle Enterprise instance at https://ge.spring.io/. This allows the Spring Session BOM project to benefit from deep build insights provided by build scans and faster build speeds for all contributors as a result of remote build caching. 

This Gradle Enterprise instance has all features and extensions enabled and is freely available for use by Spring Session BOM and all other Spring projects. On this Gradle Enterprise instance, Spring Session BOM will have access not only to all of the published build scans, but other aggregate data features such as:

- Dashboards to view all historical build scans, along with performance trends over time
- Build failure analytics for enhanced investigation and diagnosis of build failures
- Test failure analytics to better understand trends and causes around slow, failing, and flaky tests

[Spring Boot](https://ge.spring.io/scans?search.rootProjectNames=spring-boot-build), [Spring Framework](https://ge.spring.io/scans?search.rootProjectNames=spring), and [Spring Security](https://ge.spring.io/scans?search.rootProjectNames=spring-security) are already connected to https://ge.spring.io/ and are benefiting from these features. 

For these features to be made possible, appropriate access must be configured to publish build scans and to write to the remote build cache. To ensure a consistent experience for all Spring contributors, the [Spring Gradle Enterprise Conventions](https://github.com/spring-io/gradle-enterprise-conventions) plugin is used. Its documentation details how to configure credentials [to publish build scans](https://github.com/spring-io/gradle-enterprise-conventions#build-scan-publishing-credentials) and [for writing to the remote build cache](https://github.com/spring-io/gradle-enterprise-conventions#credentials).

Please let me know if there are any questions about the value of Gradle Enterprise or the changes in this pull request and I’d be happy to address them.