### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -25,7 +25,7 @@ jobs:
       - id: continue
         name: Determine if should continue
         if: env.RUN_JOBS == 'true'
-        run: echo "::set-output name=runjobs::true"
+        run: echo "runjobs=true" >> $GITHUB_OUTPUT
   
   deploy_artifacts:
     name: Deploy Artifacts


### PR DESCRIPTION
## Description

Closes #224 

Update `.github/workflows/continuous-integration-workflow.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow file that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yaml
run: echo "::set-output name=runjobs::true"
```

**TO-BE**

```yaml
run: echo "runjobs=true" >> $GITHUB_OUTPUT
```